### PR TITLE
Fixed reversed pie chart labels

### DIFF
--- a/Chart.elm
+++ b/Chart.elm
@@ -348,7 +348,7 @@ viewPie model =
                     )
                 [] -> (accOff, cols, accElems)    -- redundant
 
-        (_, _, elems) = List.foldr go (0, model.colours, []) model.items
+        (_, _, elems) = List.foldl go (0, model.colours, []) model.items
 
         legend items =
             List.map2


### PR DESCRIPTION
The labels on pie charts were being associated with the wrong colors. 

The items being displayed in the chart were being associated with different colors than those in the labels. Changing a fold right to a fold left (hopefully) resolved this bug.

As far as I can tell, this was a simple typo and my fix didn't break anything else, but let me know if it did, and I'll try to find another solution.

Thanks for this library, I'm excited for it to have more features!